### PR TITLE
Add a version compare check for the downloaded phpList version

### DIFF
--- a/index.php
+++ b/index.php
@@ -427,6 +427,22 @@ class updater
     }
 
     /**
+     * Check the downloaded phpList version. Return false if it's a downgrade.
+     * @throws UpdateException
+     * @return bool
+     */
+    function checkForDowngrade()
+    {
+        $downloadedVersion = file_get_contents(self::DOWNLOAD_PATH.'/phplist/public_html/lists/admin/init.php');
+        preg_match_all('/define\(\"VERSION\",\"(.*)\"\);/', $downloadedVersion, $matches);
+
+        if (isset($matches[1][0]) && version_compare($this->getCurrentVersion(), $matches[1][0])) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
      * Creates temporary dir
      * @throws UpdateException
      */
@@ -873,6 +889,13 @@ if (isset($_POST['action'])) {
             }
             break;
         case 10:
+            if ($update -> checkForDowngrade()) {
+                echo (json_encode(array('continue' => true, 'autocontinue' => true, 'response' => 'Not a downgrade!')));
+            } else {
+                echo(json_encode(array('continue' => false, 'response' => 'Downgrade is not supported.')));
+            }
+            break;
+        case 11:
             $on = $update->addMaintenanceMode();
             if ($on === false) {
                 echo(json_encode(array('continue' => false, 'response' => 'Cannot set the maintenance mode on!')));
@@ -880,7 +903,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => true, 'response' => 'Set maintenance mode on', 'autocontinue' => true)));
             }
             break;
-        case 11:
+        case 12:
             try {
                 $update->replacePHPEntryPoints();
                 echo(json_encode(array('continue' => true, 'response' => 'Replaced entry points', 'autocontinue' => true)));
@@ -888,7 +911,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 12:
+        case 13:
             try {
                 $update->movePluginsInTempFolder();
                 echo(json_encode(array('continue' => true, 'response' => 'Backing up the plugins', 'autocontinue' => true)));
@@ -896,7 +919,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 13:
+        case 14:
             try {
                 $update->deleteFiles();
                 echo(json_encode(array('continue' => true, 'response' => 'Old files have been deleted!', 'autocontinue' => true)));
@@ -904,7 +927,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 14:
+        case 15:
             try {
                 $update->moveNewFiles();
                 echo(json_encode(array('continue' => true, 'response' => 'Moved new files in place!', 'autocontinue' => true)));
@@ -913,7 +936,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 15:
+        case 16:
             try {
                 $update->movePluginsInPlace();
                 echo(json_encode(array('continue' => true, 'response' => 'Moved plugins in place!', 'autocontinue' => true)));
@@ -921,7 +944,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 16:
+        case 17:
             try {
                 $update->moveEntryPHPpoints();
                 echo(json_encode(array('continue' => true, 'response' => 'Moved new entry points in place!', 'autocontinue' => true)));
@@ -929,7 +952,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 17:
+        case 18:
             try {
                 $update->moveUpdater();
                 echo(json_encode(array('continue' => true, 'response' => 'Moved new entry points in place!', 'autocontinue' => true)));
@@ -937,7 +960,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 18:
+        case 19:
             try {
                 $update->deleteTemporaryFiles();
                 echo(json_encode(array('continue' => true, 'response' => 'Deleted temporary files!', 'autocontinue' => true)));
@@ -945,7 +968,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 19:
+        case 20:
             try {
                 $update->removeMaintenanceMode();
                 echo(json_encode(array('continue' => true, 'response' => 'Removed maintenance mode', 'autocontinue' => true)));
@@ -953,7 +976,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 20:
+        case 21:
             $writeStep = false;
             try {
                 $update->replaceNewUpdater();
@@ -1844,7 +1867,7 @@ if (isset($_POST['action'])) {
                 7: 1,
                 8: 2,
                 9: 2,
-                10: 3,
+                10: 2,
                 11: 3,
                 12: 3,
                 13: 3,
@@ -1855,6 +1878,7 @@ if (isset($_POST['action'])) {
                 18: 3,
                 19: 3,
                 20: 3,
+                21: 3,
             };
 
             let steps = document.querySelectorAll('.step-image');


### PR DESCRIPTION
Before moving new files in place, add a version compare check for the downloaded phpList as an extra check to make sure that the downloaded version is not a downgrade.

Mantis:https://mantis.phplist.org/view.php?id=19758