### PR TITLE
Ensure that the bundled plugins are always installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Provides an easy, automated, web-based update mechanism for phpList installation
 
 ### Usage
 
-The new phpList updater gives you an easy way to upgrade your installation via web. In four steps you can update your installation to the latest release. 
+The new phpList updater gives you an easy way to upgrade your installation via web. In four steps you can update your installation to the latest release.
 
 The Updater is available in phpList 3.3.7+.
 
@@ -23,7 +23,7 @@ The updater is currently performing the following steps. If one of those steps f
 5. Ask the user if they want a backup of the software:
  - Yes: ask the user for the location
  - If no: continue to the next step.
-  
+
 6. Download new version to a temporary folder
 7. Add maintenance mode
 8. Replace PHP entry points with "Update in progress" message
@@ -39,20 +39,20 @@ The updater is currently performing the following steps. If one of those steps f
 
 ### Permissions
 
-The whole phpList directory and the files within it must be writable by the HTTP user under which your web server is running as. 
-If there is no match between the owner of your phpList files and the user under which your web server is running, you won’t be able to update. 
+The whole phpList directory and the files within it must be writable by the HTTP user under which your web server is running as.
+If there is no match between the owner of your phpList files and the user under which your web server is running, you won’t be able to update.
 The ownership can be changed in a Linux terminal using this command:
 
 <pre> chown -R user:group /path/to/phpList-directory </pre>
 
-For instance: 
+For instance:
 
 <pre> chown -R www-data:www-data /var/www/lists </pre>
 
 Change directory and file permissions:
 
-<pre> find . -type d -exec chmod 755 {} \; </pre>  
-<pre> find . -type f -exec chmod 644 {} \; </pre> 
+<pre> find . -type d -exec chmod 755 {} \; </pre>
+<pre> find . -type f -exec chmod 644 {} \; </pre>
 
 Permissions vary from host to host. To find the HTTP user check the Apache Server configuration files.
 You can view a file's ownership, permissions, and other important information with the ls command, using the -la option:
@@ -75,7 +75,6 @@ After a successful update, please consider to re-apply any hardened directory pe
 The updater is at the moment solely focused on replacing the files of the core installation. It does neither:
 
 - Upgrade the database (this uses the existing database migration code)
-- Upgrade the plugins (this uses the existing plugin updater)
 
 ### Notes
 
@@ -83,11 +82,12 @@ The updater is at the moment solely focused on replacing the files of the core i
 - It is possible to override the backup checks by reloading the page when the backup check fails. Do not reload the page unless you wish to proceed without a backup in this case.
 - When the update process fails you should manually remove actions.txt file inside the config folder in order to reset the process and be able to try again.
 - The config directory is required to be writable because the "current step" of the automatic updater is saved inside it.
+- The plugins that are now included with phplist will be upgraded as part of the update. Any additional plugins will be kept but not upgraded.
 
 ### Future development plans
 
 At the moment only our current stable release, phpList 3, is supported by the updater. We’ll work on adding support to our upcoming phpList 4 release.
 
-### Report bugs and improvements: 
+### Report bugs and improvements:
 https://mantis.phplist.org/set_project.php?project_id=2;185
 

--- a/index.php
+++ b/index.php
@@ -737,17 +737,24 @@ class updater
     }
 
     /**
-     * Move plugins back in admin directory.
+     * Move any additional plugin files and directories back to the admin directory.
      * @throws UpdateException
      */
     function movePluginsInPlace()
     {
         $oldDir = realpath(__DIR__ . '/../tmp_uploaded_update/tempplugins');
         $newDir = realpath(__DIR__ . '/../admin/plugins');
-        $this->rmdir_recursive($newDir);
-        $state = rename($oldDir, $newDir);
-        if ($state === false) {
-            throw new UpdateException("Could not move plugins directory to admin folder.");
+
+        $existingPluginFiles = scandir($oldDir);
+        $newPluginFiles = scandir($newDir);
+        $additional = array_diff($existingPluginFiles, $newPluginFiles);
+
+        foreach ($additional as $file) {
+            $state = rename("$oldDir/$file", "$newDir/$file");
+
+            if ($state === false) {
+                throw new UpdateException("Could not restore plugin $file.");
+            }
         }
     }
 


### PR DESCRIPTION
This earlier change https://github.com/phpList/updater/commit/4e92421555e9cf7c7c582a0ddab26bd91c0e06bb#diff-828e0013b8f3bc1bb22b4f57172b019d
stopped updating the plugins that are included with phplist, meaning that the plugins had to be upgraded manually. I think that the reason was that any additional installed plugins were being removed as part of the update.

This causes a problem when there are related changes to phplist and to a plugin, such as the recent changes to the session name.
Anyone updating to phplist 3.5.5 then has incompatible versions of phplist and the ckeditor plugin causing the kcfinder file browser not to work ("You do not have permissions" error).

An improved approach is for the updater to overwrite the plugins directory then restore only any additional plugins (files and directories). This allows the bundled plugins to always be installed as part of the update, ensuring that they will be up to date.

The "additional plugins" are any files and directories in the existing plugins directory that are not in the plugins directory of the new release.
