### PR TITLE
update jQuery reference to version 3.6.0

### DIFF
--- a/index.php
+++ b/index.php
@@ -1771,8 +1771,8 @@ if (isset($_POST['action'])) {
     </div><!-- .inner -->
     </div><!-- .outer -->
 
-    <!-- Load jquery-3.3.1.min.js file -->
-    <script type="text/javascript" src="../admin/js/jquery-3.3.1.min.js"></script>
+    <!-- Load jquery-3.6.0.min.js file -->
+    <script type="text/javascript" src="../admin/js/jquery-3.6.0.min.js"></script>
 
     <!-- script for arrow animation -->
     <script type="text/javascript">


### PR DESCRIPTION
As part of updating the jQuery version in use in phplist3 to 3.6.0 here: https://github.com/phpList/phplist3/pull/818 this repository likely also needs to be updated to match.

If this PR is not necessary, please feel free to close it.