### PR TITLE
Improve error handling and reporting

### DIFF
--- a/index.php
+++ b/index.php
@@ -414,7 +414,7 @@ class updater
         curl_setopt($ch, CURLOPT_FILE, fopen($zipFile, 'w+'));
         $page = curl_exec($ch);
         if (!$page) {
-            echo "Error :- " . curl_error($ch);
+            throw new \UpdateException('Error: ' . curl_error($ch));
         }
         curl_close($ch);
 
@@ -589,7 +589,9 @@ class updater
             throw new \UpdateException("Error: Unable to open the Zip File");
         }
         /* Extract Zip File */
-        $zip->extractTo($extractPath);
+        if (!$zip->extractTo($extractPath)) {
+            throw new \UpdateException("Error: Unable to extract the Zip File");
+        }
         $zip->close();
 
     }
@@ -769,8 +771,8 @@ try {
     $update->checkConfig();
     $update->checkphpmodules();
 
-} catch (\UpdateException $e) {
-    throw $e;
+} catch (\Exception $e) {
+    die($e->getMessage());
 }
 
 /**
@@ -779,194 +781,198 @@ try {
  *
  */
 if (isset($_POST['action'])) {
-    set_time_limit(0);
+    try {
+        set_time_limit(0);
 
-    //ensure that $action is integer
+        //ensure that $action is integer
 
-    $action = (int)$_POST['action'];
+        $action = (int)$_POST['action'];
 
-    header('Content-Type: application/json');
-    $writeStep = true;
-    switch ($action) {
-        case 0:
-            $statusJson = $update->currentUpdateStep();
-            echo json_encode(array('status' => $statusJson, 'autocontinue' => true));
-            break;
-        case 1:
-            $updateMessage = $update->checkIfThereIsAnUpdate();
-            $isThereAnUpdate = $update->availableUpdate();
-            if ($isThereAnUpdate === false) {
-                echo(json_encode(array('continue' => false, 'response' => $updateMessage)));
-            } else {
-                echo(json_encode(array('continue' => true, 'response' => $updateMessage)));
-            }
-            break;
-        case 2:
-            echo(json_encode(array('continue' => true, 'autocontinue' => true, 'response' => 'Starting integrity check')));
-            break;
-        case 3:
-            $unexpectedFiles = $update->checkRequiredFiles();
-            if (count($unexpectedFiles) !== 0) {
-                $elements = "Error: The following files are either not expected and should be removed, or are missing but required and should be put back in place \n";
-                foreach ($unexpectedFiles as $key => $fileName) {
-                    $elements .= $key . "\n";
+        header('Content-Type: application/json');
+        $writeStep = true;
+        switch ($action) {
+            case 0:
+                $statusJson = $update->currentUpdateStep();
+                echo json_encode(array('status' => $statusJson, 'autocontinue' => true));
+                break;
+            case 1:
+                $updateMessage = $update->checkIfThereIsAnUpdate();
+                $isThereAnUpdate = $update->availableUpdate();
+                if ($isThereAnUpdate === false) {
+                    echo(json_encode(array('continue' => false, 'response' => $updateMessage)));
+                } else {
+                    echo(json_encode(array('continue' => true, 'response' => $updateMessage)));
                 }
-                echo(json_encode(array('retry' => true, 'continue' => false, 'response' => $elements)));
-            } else {
-                echo(json_encode(array('continue' => true, 'response' => 'Integrity check successful', 'autocontinue' => true)));
-            }
-            break;
-        case 4:
-            $notWriteableFiles = $update->checkWritePermissions();
-            if (count($notWriteableFiles) !== 0) {
-                $notWriteableElements = "Error: No write permission for the following files: \n";;
-                foreach ($notWriteableFiles as $key => $fileName) {
-                    $notWriteableElements .= $fileName . "\n";
+                break;
+            case 2:
+                echo(json_encode(array('continue' => true, 'autocontinue' => true, 'response' => 'Starting integrity check')));
+                break;
+            case 3:
+                $unexpectedFiles = $update->checkRequiredFiles();
+                if (count($unexpectedFiles) !== 0) {
+                    $elements = "Error: The following files are either not expected and should be removed, or are missing but required and should be put back in place \n";
+                    foreach ($unexpectedFiles as $key => $fileName) {
+                        $elements .= $key . "\n";
+                    }
+                    echo(json_encode(array('retry' => true, 'continue' => false, 'response' => $elements)));
+                } else {
+                    echo(json_encode(array('continue' => true, 'response' => 'Integrity check successful', 'autocontinue' => true)));
                 }
-                echo(json_encode(array('retry' => true, 'continue' => false, 'response' => $notWriteableElements)));
-            } else {
-                echo(json_encode(array('continue' => true, 'response' => 'Write check successful.', 'autocontinue' => true)));
-            }
-            break;
-        case 5:
-            echo(json_encode(array('continue' => true, 'response' => 'Do you want a backup? <form><input type="radio" name="create_backup" value="true">Yes<br><input type="radio" name="create_backup" value="false" checked>No</form>')));
-            break;
-        case 6:
-            $createBackup = $_POST['create_backup'];
-            if ($createBackup === 'true') {
-                echo(json_encode(array('continue' => true, 'response' => 'Choose location where to backup the /lists directory. Please make sure to choose a location outside the web root:<br> <form onsubmit="return false;"><input type="text" id="backuplocation" size="55" name="backup_location" placeholder="/var/backup.zip" /></form>')));
-            } else {
-                echo(json_encode(array('continue' => true, 'response' => '', 'autocontinue' => true)));
-            }
-            break;
-        case 7:
-            $createBackup = $_POST['create_backup'];
-            if ($createBackup === 'true') {
-                $backupLocation = realpath(dirname($_POST['backup_location']));
-                $phplistRootFolder = realpath(__DIR__ . '/../../');
-                if (strpos($backupLocation, $phplistRootFolder) === 0) {
-                    echo(json_encode(array('retry' => true, 'continue' => false, 'response' => 'Error: Please choose a folder outside of your phpList installation.')));
-                    break;
+                break;
+            case 4:
+                $notWriteableFiles = $update->checkWritePermissions();
+                if (count($notWriteableFiles) !== 0) {
+                    $notWriteableElements = "Error: No write permission for the following files: \n";;
+                    foreach ($notWriteableFiles as $key => $fileName) {
+                        $notWriteableElements .= $fileName . "\n";
+                    }
+                    echo(json_encode(array('retry' => true, 'continue' => false, 'response' => $notWriteableElements)));
+                } else {
+                    echo(json_encode(array('continue' => true, 'response' => 'Write check successful.', 'autocontinue' => true)));
                 }
-                if (!preg_match("/^.*\.(zip)$/i", $_POST['backup_location'])) {
-                    echo(json_encode(array('retry' => true, 'continue' => false, 'response' => 'Error: Please add .zip extension.')));
-                    break;
+                break;
+            case 5:
+                echo(json_encode(array('continue' => true, 'response' => 'Do you want a backup? <form><input type="radio" name="create_backup" value="true">Yes<br><input type="radio" name="create_backup" value="false" checked>No</form>')));
+                break;
+            case 6:
+                $createBackup = $_POST['create_backup'];
+                if ($createBackup === 'true') {
+                    echo(json_encode(array('continue' => true, 'response' => 'Choose location where to backup the /lists directory. Please make sure to choose a location outside the web root:<br> <form onsubmit="return false;"><input type="text" id="backuplocation" size="55" name="backup_location" placeholder="/var/backup.zip" /></form>')));
+                } else {
+                    echo(json_encode(array('continue' => true, 'response' => '', 'autocontinue' => true)));
                 }
+                break;
+            case 7:
+                $createBackup = $_POST['create_backup'];
+                if ($createBackup === 'true') {
+                    $backupLocation = realpath(dirname($_POST['backup_location']));
+                    $phplistRootFolder = realpath(__DIR__ . '/../../');
+                    if (strpos($backupLocation, $phplistRootFolder) === 0) {
+                        echo(json_encode(array('retry' => true, 'continue' => false, 'response' => 'Error: Please choose a folder outside of your phpList installation.')));
+                        break;
+                    }
+                    if (!preg_match("/^.*\.(zip)$/i", $_POST['backup_location'])) {
+                        echo(json_encode(array('retry' => true, 'continue' => false, 'response' => 'Error: Please add .zip extension.')));
+                        break;
+                    }
+                    try {
+                        $update->backUpFiles($_POST['backup_location']);
+                        echo(json_encode(array('continue' => true, 'response' => 'Backup has been created')));
+                    } catch (\Exception $e) {
+                        echo(json_encode(array('retry' => true, 'continue' => false, 'response' => $e->getMessage())));
+                        break;
+                    }
+                } else {
+                    echo(json_encode(array('continue' => true, 'response' => 'No back up created', 'autocontinue' => true)));
+                }
+
+                break;
+            case 8:
+                echo(json_encode(array('continue' => true, 'autocontinue' => true, 'response' => 'Download in progress')));
+                break;
+            case 9:
                 try {
-                    $update->backUpFiles($_POST['backup_location']);
-                    echo(json_encode(array('continue' => true, 'response' => 'Backup has been created')));
+                    $update->downloadUpdate();
+                    echo(json_encode(array('continue' => true, 'response' => 'The update has been downloaded!')));
                 } catch (\Exception $e) {
-                    echo(json_encode(array('retry' => true, 'continue' => false, 'response' => $e->getMessage())));
-                    break;
+                    echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
                 }
-            } else {
-                echo(json_encode(array('continue' => true, 'response' => 'No back up created', 'autocontinue' => true)));
-            }
+                break;
+            case 10:
+                $on = $update->addMaintenanceMode();
+                if ($on === false) {
+                    echo(json_encode(array('continue' => false, 'response' => 'Cannot set the maintenance mode on!')));
+                } else {
+                    echo(json_encode(array('continue' => true, 'response' => 'Set maintenance mode on', 'autocontinue' => true)));
+                }
+                break;
+            case 11:
+                try {
+                    $update->replacePHPEntryPoints();
+                    echo(json_encode(array('continue' => true, 'response' => 'Replaced entry points', 'autocontinue' => true)));
+                } catch (\Exception $e) {
+                    echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
+                }
+                break;
+            case 12:
+                try {
+                    $update->movePluginsInTempFolder();
+                    echo(json_encode(array('continue' => true, 'response' => 'Backing up the plugins', 'autocontinue' => true)));
+                } catch (\Exception $e) {
+                    echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
+                }
+                break;
+            case 13:
+                try {
+                    $update->deleteFiles();
+                    echo(json_encode(array('continue' => true, 'response' => 'Old files have been deleted!', 'autocontinue' => true)));
+                } catch (\Exception $e) {
+                    echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
+                }
+                break;
+            case 14:
+                try {
+                    $update->moveNewFiles();
+                    echo(json_encode(array('continue' => true, 'response' => 'Moved new files in place!', 'autocontinue' => true)));
 
-            break;
-        case 8:
-            echo(json_encode(array('continue' => true, 'autocontinue' => true, 'response' => 'Download in progress')));
-            break;
-        case 9:
-            try {
-                $update->downloadUpdate();
-                echo(json_encode(array('continue' => true, 'response' => 'The update has been downloaded!')));
-            } catch (\Exception $e) {
-                echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
-            }
-            break;
-        case 10:
-            $on = $update->addMaintenanceMode();
-            if ($on === false) {
-                echo(json_encode(array('continue' => false, 'response' => 'Cannot set the maintenance mode on!')));
-            } else {
-                echo(json_encode(array('continue' => true, 'response' => 'Set maintenance mode on', 'autocontinue' => true)));
-            }
-            break;
-        case 11:
-            try {
-                $update->replacePHPEntryPoints();
-                echo(json_encode(array('continue' => true, 'response' => 'Replaced entry points', 'autocontinue' => true)));
-            } catch (\Exception $e) {
-                echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
-            }
-            break;
-        case 12:
-            try {
-                $update->movePluginsInTempFolder();
-                echo(json_encode(array('continue' => true, 'response' => 'Backing up the plugins', 'autocontinue' => true)));
-            } catch (\Exception $e) {
-                echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
-            }
-            break;
-        case 13:
-            try {
-                $update->deleteFiles();
-                echo(json_encode(array('continue' => true, 'response' => 'Old files have been deleted!', 'autocontinue' => true)));
-            } catch (\Exception $e) {
-                echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
-            }
-            break;
-        case 14:
-            try {
-                $update->moveNewFiles();
-                echo(json_encode(array('continue' => true, 'response' => 'Moved new files in place!', 'autocontinue' => true)));
-
-            } catch (\Exception $e) {
-                echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
-            }
-            break;
-        case 15:
-            try {
-                $update->movePluginsInPlace();
-                echo(json_encode(array('continue' => true, 'response' => 'Moved plugins in place!', 'autocontinue' => true)));
-            } catch (\Exception $e) {
-                echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
-            }
-            break;
-        case 16:
-            try {
-                $update->moveEntryPHPpoints();
-                echo(json_encode(array('continue' => true, 'response' => 'Moved new entry points in place!', 'autocontinue' => true)));
-            } catch (\Exception $e) {
-                echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
-            }
-            break;
-        case 17:
-            try {
-                $update->moveUpdater();
-                echo(json_encode(array('continue' => true, 'response' => 'Moved new entry points in place!', 'autocontinue' => true)));
-            } catch (\Exception $e) {
-                echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
-            }
-            break;
-        case 18:
-            try {
-                $update->deleteTemporaryFiles();
-                echo(json_encode(array('continue' => true, 'response' => 'Deleted temporary files!', 'autocontinue' => true)));
-            } catch (\Exception $e) {
-                echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
-            }
-            break;
-        case 19:
-            try {
-                $update->removeMaintenanceMode();
-                echo(json_encode(array('continue' => true, 'response' => 'Removed maintenance mode', 'autocontinue' => true)));
-            } catch (\Exception $e) {
-                echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
-            }
-            break;
-        case 20:
-            $writeStep = false;
-            try {
-                $update->replaceNewUpdater();
-                $update->deauthUpdaterSession();
-                echo(json_encode(array('continue' => true, 'nextUrl' => '../admin/', 'response' => 'Updated successfully.')));
-            } catch (\Exception $e) {
-                echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
-            }
-            break;
-    };
+                } catch (\Exception $e) {
+                    echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
+                }
+                break;
+            case 15:
+                try {
+                    $update->movePluginsInPlace();
+                    echo(json_encode(array('continue' => true, 'response' => 'Moved plugins in place!', 'autocontinue' => true)));
+                } catch (\Exception $e) {
+                    echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
+                }
+                break;
+            case 16:
+                try {
+                    $update->moveEntryPHPpoints();
+                    echo(json_encode(array('continue' => true, 'response' => 'Moved new entry points in place!', 'autocontinue' => true)));
+                } catch (\Exception $e) {
+                    echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
+                }
+                break;
+            case 17:
+                try {
+                    $update->moveUpdater();
+                    echo(json_encode(array('continue' => true, 'response' => 'Moved new entry points in place!', 'autocontinue' => true)));
+                } catch (\Exception $e) {
+                    echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
+                }
+                break;
+            case 18:
+                try {
+                    $update->deleteTemporaryFiles();
+                    echo(json_encode(array('continue' => true, 'response' => 'Deleted temporary files!', 'autocontinue' => true)));
+                } catch (\Exception $e) {
+                    echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
+                }
+                break;
+            case 19:
+                try {
+                    $update->removeMaintenanceMode();
+                    echo(json_encode(array('continue' => true, 'response' => 'Removed maintenance mode', 'autocontinue' => true)));
+                } catch (\Exception $e) {
+                    echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
+                }
+                break;
+            case 20:
+                $writeStep = false;
+                try {
+                    $update->replaceNewUpdater();
+                    $update->deauthUpdaterSession();
+                    echo(json_encode(array('continue' => true, 'nextUrl' => '../admin/', 'response' => 'Updated successfully.')));
+                } catch (\Exception $e) {
+                    echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
+                }
+                break;
+        }
+    } catch (\Exception $e) {
+        echo(json_encode(array('continue' => false, 'response' => 'Error: ' . $e->getMessage())));
+    }
 
     if ($writeStep) {
         try {

--- a/index.php
+++ b/index.php
@@ -424,22 +424,6 @@ class updater
     }
 
     /**
-     * Check the downloaded phpList version. Return false if it's a downgrade.
-     * @throws UpdateException
-     * @return bool
-     */
-    function checkForDowngrade()
-    {
-        $downloadedVersion = file_get_contents(self::DOWNLOAD_PATH.'/phplist/public_html/lists/admin/init.php');
-        preg_match_all('/define\(\"VERSION\",\"(.*)\"\);/', $downloadedVersion, $matches);
-
-        if (isset($matches[1][0]) && version_compare($this->getCurrentVersion(), $matches[1][0])) {
-            return true;
-        }
-        return false;
-    }
-
-    /**
      * Creates temporary dir
      * @throws UpdateException
      */
@@ -892,13 +876,6 @@ if (isset($_POST['action'])) {
             }
             break;
         case 10:
-            if ($update -> checkForDowngrade()) {
-                echo (json_encode(array('continue' => true, 'autocontinue' => true, 'response' => 'Not a downgrade!')));
-            } else {
-                echo(json_encode(array('continue' => false, 'response' => 'Downgrade is not supported.')));
-            }
-            break;
-        case 11:
             $on = $update->addMaintenanceMode();
             if ($on === false) {
                 echo(json_encode(array('continue' => false, 'response' => 'Cannot set the maintenance mode on!')));
@@ -906,7 +883,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => true, 'response' => 'Set maintenance mode on', 'autocontinue' => true)));
             }
             break;
-        case 12:
+        case 11:
             try {
                 $update->replacePHPEntryPoints();
                 echo(json_encode(array('continue' => true, 'response' => 'Replaced entry points', 'autocontinue' => true)));
@@ -914,7 +891,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 13:
+        case 12:
             try {
                 $update->movePluginsInTempFolder();
                 echo(json_encode(array('continue' => true, 'response' => 'Backing up the plugins', 'autocontinue' => true)));
@@ -922,7 +899,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 14:
+        case 13:
             try {
                 $update->deleteFiles();
                 echo(json_encode(array('continue' => true, 'response' => 'Old files have been deleted!', 'autocontinue' => true)));
@@ -930,7 +907,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 15:
+        case 14:
             try {
                 $update->moveNewFiles();
                 echo(json_encode(array('continue' => true, 'response' => 'Moved new files in place!', 'autocontinue' => true)));
@@ -939,7 +916,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 16:
+        case 15:
             try {
                 $update->movePluginsInPlace();
                 echo(json_encode(array('continue' => true, 'response' => 'Moved plugins in place!', 'autocontinue' => true)));
@@ -947,7 +924,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 17:
+        case 16:
             try {
                 $update->moveEntryPHPpoints();
                 echo(json_encode(array('continue' => true, 'response' => 'Moved new entry points in place!', 'autocontinue' => true)));
@@ -955,7 +932,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 18:
+        case 17:
             try {
                 $update->moveUpdater();
                 echo(json_encode(array('continue' => true, 'response' => 'Moved new entry points in place!', 'autocontinue' => true)));
@@ -963,7 +940,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 19:
+        case 18:
             try {
                 $update->deleteTemporaryFiles();
                 echo(json_encode(array('continue' => true, 'response' => 'Deleted temporary files!', 'autocontinue' => true)));
@@ -971,7 +948,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 20:
+        case 19:
             try {
                 $update->removeMaintenanceMode();
                 echo(json_encode(array('continue' => true, 'response' => 'Removed maintenance mode', 'autocontinue' => true)));
@@ -979,7 +956,7 @@ if (isset($_POST['action'])) {
                 echo(json_encode(array('continue' => false, 'response' => $e->getMessage())));
             }
             break;
-        case 21:
+        case 20:
             $writeStep = false;
             try {
                 $update->replaceNewUpdater();
@@ -1864,7 +1841,7 @@ if (isset($_POST['action'])) {
                 7: 1,
                 8: 2,
                 9: 2,
-                10: 2,
+                10: 3,
                 11: 3,
                 12: 3,
                 13: 3,
@@ -1875,7 +1852,6 @@ if (isset($_POST['action'])) {
                 18: 3,
                 19: 3,
                 20: 3,
-                21: 3,
             };
 
             let steps = document.querySelectorAll('.step-image');


### PR DESCRIPTION
There are still reports in the user forum of problems with using the updater. Mostly either it stops with no indication of the problem, or "Downgrade not supported" is displayed which is probably a misleading result of an earlier problem.
Also the way that the updater identifies and handles the current version is a bit unclear and possibly error-prone.

There are three commits here:
1) get the current version from the config table instead of parsing the init.php file. Show that a new release is available only when the installed version is lower than the latest version.
2) Remove step 10 "Check for downgrade" which now cannot happen due to 1) 
3) Add throwing an exception when downloading or unzipping the new release fails. Add a catch-all try/catch for any unhandled exceptions to allow a json response to be sent to the browser.

Together these should at least provide more information to the user if something goes wrong with the update.